### PR TITLE
Enclose path with double quotes, rename ruby function

### DIFF
--- a/node/perlModule.js
+++ b/node/perlModule.js
@@ -8,7 +8,7 @@ maxerr: 50, node: true */
     var exec = require('child_process').exec;
 
     function runPerlCode(filePath){
-        exec('perl '+filePath, function (error, stdout, stderr) {
+        exec('perl "'+filePath+'"', function (error, stdout, stderr) {
             // output is in stdout
             console.log(stdout);
         });

--- a/node/phpModule.js
+++ b/node/phpModule.js
@@ -8,7 +8,7 @@ maxerr: 50, node: true */
     var exec = require('child_process').exec;
 
     function runPHPCode(filePath){
-        exec('php '+filePath, function (error, stdout, stderr) {
+        exec('php "'+filePath+'"', function (error, stdout, stderr) {
             // output is in stdout
             console.log(stdout);
         });

--- a/node/rubyModule.js
+++ b/node/rubyModule.js
@@ -7,8 +7,8 @@ maxerr: 50, node: true */
     "use strict";
     var exec = require('child_process').exec;
 
-    function runPHPCode(filePath){
-        exec('ruby '+filePath, function (error, stdout, stderr) {
+    function runRubyCode(filePath){
+        exec('ruby "'+filePath+'"', function (error, stdout, stderr) {
             // output is in stdout
             console.log(stdout);
         });
@@ -21,7 +21,7 @@ maxerr: 50, node: true */
         domainManager.registerCommand(
             "ruby", // domain name
             "runRubyCode", // command name
-            runPHPCode, // command handler function
+            runRubyCode, // command handler function
             false, // this command is synchronous in Node
             "Run Ruby code",
             [{name: "filePath", // parameters


### PR DESCRIPTION
In Mac OS X, error may occurred when exec php/ruby/perl because the file path contains space,
e.g.
 /Users/{username}/Library/Application Support/Brackets/extensions/user/deddy.runscript/code.php
